### PR TITLE
Add runtime argument to force attempt download even without CC installed

### DIFF
--- a/ccdl.command
+++ b/ccdl.command
@@ -39,4 +39,4 @@ python3 -c "import tqdm" || pip3 install --user tqdm
 
 echo "${CYAN}starting ccdl${RESET}"
 cd "$(dirname "$0")"
-python3 "./ccdl.py $@"
+python3 "./ccdl.py"

--- a/ccdl.command
+++ b/ccdl.command
@@ -39,4 +39,4 @@ python3 -c "import tqdm" || pip3 install --user tqdm
 
 echo "${CYAN}starting ccdl${RESET}"
 cd "$(dirname "$0")"
-python3 "./ccdl.py"
+python3 "./ccdl.py $@"

--- a/ccdl.py
+++ b/ccdl.py
@@ -642,9 +642,13 @@ if __name__ == '__main__':
                         help='Set the architecture to download', action='store')
     parser.add_argument('--ignoreNoCreativeCloud',
                         help='Ignore no creative cloud and just fallback to generic icon', action='store_true')
+    parser.add_argument('--noRepeatPrompt', help="Don't prompt for additional downloads", action='store_true'),
     args = parser.parse_args()
 
     runcc = True
     while runcc:
         runccdl()
-        runcc = questiony('\n\nDo you want to create another package')
+        if args.noRepeatPrompt:
+            runcc = False
+        else:
+            runcc = questiony('\n\nDo you want to create another package')

--- a/ccdl.py
+++ b/ccdl.py
@@ -27,7 +27,6 @@ import os
 import platform
 import shutil
 import sys
-import pathlib
 from collections import OrderedDict
 from subprocess import PIPE, Popen
 from xml.etree import ElementTree as ET
@@ -637,7 +636,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-v', '--version', help='Version of desired product (eg. 21.0.3)', action='store')
     parser.add_argument('-d', '--destination',
-                        help='Directory to download installation files to', action='store', type=pathlib.Path)
+                        help='Directory to download installation files to', action='store')
     parser.add_argument('-a', '--arch',
                         help='Set the architecture to download', action='store')
     parser.add_argument('--ignoreNoCreativeCloud',


### PR DESCRIPTION
Added the following changes:
- Added argument to allow force download even without CC installed, this means that installer icon will use generic cd icon from system if CC is not found, however
  - E.g. for when downloading for another system
- Added argument to suppress prompt for additional downloads (e.g. for batch downloading via xargs, etc)
- Added argument to provide OS language
- Added argument to skip downloading existing files, e.g. when retrying failed download so already downloaded files don't have to be downloaded again
- Update ccdl.command to pass arguments to ccdl.py